### PR TITLE
Remove backticks from YAML block

### DIFF
--- a/sample.md
+++ b/sample.md
@@ -1,10 +1,8 @@
-```
-    ---  
-    title: Plain Text Workflow  
-    author: Dennis Tenen, Grant Wythoff  
-    date: January 20, 2014  
-    ---  
-```
+---
+title: Plain Text Workflow  
+author: Dennis Tenen, Grant Wythoff  
+date: January 20, 2014  
+---
 
 # Section 1  
  


### PR DESCRIPTION
This is needed to make your Programming Historian lesson's sample codeblock match the downloadable sample file. Backticks around the YAML header causes attempts to process this to fail. See https://github.com/programminghistorian/jekyll/issues/146.
